### PR TITLE
New and improved command line syntax

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             // Resolved by CMake Tools:
             "program": "${command:cmake.launchTargetPath}",
             "args": [
-                "1", "1000000000", "8", "build/test1"
+                "sieve", "end=1000000000", "threads=8", "outfile=build/test1"
             ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,11 @@
         "bitarray.h": "c",
         "stdafx.h": "c",
         "utils.h": "c",
-        "time.h": "c"
+        "time.h": "c",
+        "random": "c",
+        "limits": "c",
+        "algorithm": "c",
+        "ranges": "c",
+        "vector": "c"
     }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(PrimeFDG
     src/pevents_c.cpp
     src/pfdg.c
 	src/cli.c
-    src/PrimeFDG.c
+    src/main.c
 )
 target_link_libraries(PrimeFDG PRIVATE m)
 target_link_libraries(PrimeFDG PRIVATE gomp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(PrimeFDG
     src/pevents.cpp
     src/pevents_c.cpp
     src/pfdg.c
+	src/cli.c
     src/PrimeFDG.c
 )
 target_link_libraries(PrimeFDG PRIVATE m)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ maxmem: Limits the maximum amount of memory to use for computation. Supports exp
 outfile: The path to a file to which the computation results will be stored. If unspecified, the results will be discarded immediately.
 
 Usage example: primefdg sieve start=1 end=1e12 threads=8
+
+Exponent specifiers (base 10): k,m,g,t,e
+Exponent specifiers (base 2): K,M,G,T
 ```
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -3,6 +3,31 @@ Find prime numbers using an optimized, multithreaded and segmented Sieve of Erat
 
 The successor to my previous related projects.
 
+## Usage
+
+**Note: The usage has changed recently**
+
+```
+Usage: primefdg <command> [<argument>=<value>...]
+(the syntax is similar to dd)
+
+Available commands:
+help: Prints this message. This command does not accept arguments.
+test: Runs a memcpy speed test. This command does not accept arguments.
+sieve: Finds prime numbers within a given range.
+mem: Calculates the estimated memory usage of a sieve command with the same arguments.
+
+Available arguments:
+start: The start of the range in which to find prime numbers. Supports exponent specifiers. Values below 3 are set to 3. If unspecified, will be set to 0.
+end: The end of the range in which to find prime numbers. Supports exponent specifiers. Required.
+threads: The number of threads to use for computation. If unspecified or equal to 0, will be set to the number of CPU threads available.
+chunks: The number of tasks that the computation will be split into. Supports exponent specifiers. This is an advanced option that can be used to tune performance. If unspecified, the value will be calculated as such: threads * 2^MAX(floor(log10(end)) - 1, 0)
+maxmem: Limits the maximum amount of memory to use for computation. Supports exponent specifiers.
+outfile: The path to a file to which the computation results will be stored. If unspecified, the results will be discarded immediately.
+
+Usage example: primefdg sieve start=1 end=1e12 threads=8
+```
+
 ## Building
 ### On Linux (CMake + GCC)
 Prerequisites (on Debian):

--- a/src/PrimeFDG.vcxproj
+++ b/src/PrimeFDG.vcxproj
@@ -84,7 +84,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
@@ -101,7 +101,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
@@ -186,7 +186,7 @@
     <ClCompile Include="pevents.cpp" />
     <ClCompile Include="pevents_c.cpp" />
     <ClCompile Include="pfdg.c" />
-    <ClCompile Include="PrimeFDG.c" />
+    <ClCompile Include="main.c" />
   </ItemGroup>
   <ItemGroup>
     <None Include="cpp.hint" />

--- a/src/PrimeFDG.vcxproj
+++ b/src/PrimeFDG.vcxproj
@@ -164,6 +164,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="bitarray.h" />
+    <ClInclude Include="cli.h" />
     <ClInclude Include="cpuid.h" />
     <ClInclude Include="io.h" />
     <ClInclude Include="pevents.h" />
@@ -179,6 +180,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="bitarray.c" />
+    <ClCompile Include="cli.c" />
     <ClCompile Include="cpuid.c" />
     <ClCompile Include="io.c" />
     <ClCompile Include="pevents.cpp" />

--- a/src/PrimeFDG.vcxproj.filters
+++ b/src/PrimeFDG.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClInclude Include="pevents_c.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="cli.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="bitarray.c">
@@ -75,6 +78,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="pevents_c.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="cli.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/PrimeFDG.vcxproj.filters
+++ b/src/PrimeFDG.vcxproj.filters
@@ -62,7 +62,7 @@
     <ClCompile Include="bitarray.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="PrimeFDG.c">
+    <ClCompile Include="main.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="pfdg.c">

--- a/src/bitarray.c
+++ b/src/bitarray.c
@@ -8,6 +8,17 @@
 #include <x86intrin.h>
 #endif
 
+uint64_t bitarray_get_required_mem(const uint64_t capacity, const bool oddonly)
+{
+	// Number of bits required
+	const uint64_t br = DIVUP(capacity, (oddonly + 1));
+	// Number of words required
+	const uint64_t wr = DIVUP(br, BITS(BITARRAY_WORD));
+	// Aligned just in case we ever use SIMD
+	const uint64_t bytes = DIVUP(wr * sizeof(BITARRAY_WORD), 32) * 32;
+	return bytes + sizeof(bitarray);
+}
+
 bitarray * bitarray_create(const uint64_t capacity, const bool oddonly)
 {
 	// Number of bits required

--- a/src/bitarray.h
+++ b/src/bitarray.h
@@ -9,6 +9,7 @@ typedef struct
 	bool oddonly;
 } bitarray;
 
+uint64_t bitarray_get_required_mem(const uint64_t capacity, const bool oddonly);
 bitarray * bitarray_create(const uint64_t capacity, const bool oddonly);
 void bitarray_set(bitarray * const b, const uint64_t i);
 void bitarray_unset(bitarray * const b, const uint64_t i);

--- a/src/cli.c
+++ b/src/cli.c
@@ -12,6 +12,11 @@
 #define STRICMP strcasecmp
 #endif
 
+#define KiB (1ull << 10)
+#define MiB (1ull << 20)
+#define GiB (1ull << 30)
+#define TiB (1ull << 40)
+
 bool pfdg_cli_parse_number(char *value_str, uint64_t *res)
 {
 	char *end;
@@ -31,7 +36,7 @@ bool pfdg_cli_parse_number(char *value_str, uint64_t *res)
 			++end;
 			break;
 		case 'K':
-			scale = 1ull << 10;
+			scale = KiB;
 			++end;
 			break;
 		case 'm':
@@ -39,7 +44,7 @@ bool pfdg_cli_parse_number(char *value_str, uint64_t *res)
 			++end;
 			break;
 		case 'M':
-			scale = 1ull << 20;
+			scale = MiB;
 			++end;
 			break;
 		case 'g':
@@ -47,7 +52,7 @@ bool pfdg_cli_parse_number(char *value_str, uint64_t *res)
 			++end;
 			break;
 		case 'G':
-			scale = 1ull << 30;
+			scale = GiB;
 			++end;
 			break;
 		case 't':
@@ -55,7 +60,7 @@ bool pfdg_cli_parse_number(char *value_str, uint64_t *res)
 			++end;
 			break;
 		case 'T':
-			scale = 1ull << 40;
+			scale = TiB;
 			++end;
 			break;
 		case 'e':
@@ -343,4 +348,28 @@ pfdg_args_t *pfdg_cli_parse(const int argc, char **argv)
 void pfdg_cli_destroy(pfdg_args_t *args)
 {
 	free(args);
+}
+
+void pfdg_cli_print_bytes(uint64_t bytes)
+{
+	if (bytes < KiB)
+	{
+		printf("%llu bytes", bytes);
+	}
+	else if (bytes < MiB)
+	{
+		printf("%.2f KiB", (double)bytes / KiB);
+	}
+	else if (bytes < GiB)
+	{
+		printf("%.2f MiB", (double)(bytes / KiB) / KiB);
+	}
+	else if (bytes < TiB)
+	{
+		printf("%.2f GiB", (double)(bytes / MiB) / KiB);
+	}
+	else
+	{
+		printf("%.2f TiB", (double)(bytes / GiB) / KiB);
+	}
 }

--- a/src/cli.c
+++ b/src/cli.c
@@ -226,13 +226,19 @@ pfdg_args_t* pfdg_cli_parse(const int argc, char** argv)
 		return args;
 	}
 
-	// TODO: Apply defaults for maxmem and threads
+	if (args->threads > 0)
+		omp_set_num_threads(args->threads);
+	else
+		args->threads = omp_get_max_threads();
+
 	if (args->chunks == 0)
 	{
 		uint64_t l = (uint64_t)log10floor(args->end);
 		if (l > 0) l--;
 		args->chunks = (uint64_t)args->threads << l;
 	}
+	
+	// TODO: Apply defaults for maxmem
 
 	return args;
 }

--- a/src/cli.c
+++ b/src/cli.c
@@ -1,0 +1,98 @@
+#include "cli.h"
+#include <stdlib.h>
+#include <string.h>
+
+#if _MSC_VER
+#define STRNICMP _strnicmp
+#define STRICMP _stricmp
+#else
+#define STRNICMP strncasecmp
+#define STRICMP strcasecmp
+#endif
+
+pfdg_args_t* pfdg_cli_parse(const int argc, char** argv)
+{
+	pfdg_args_t* args = malloc(sizeof(pfdg_args_t));
+	if (!args) return NULL;
+	args->command = pfdg_command_none;
+	args->start = 1;
+	args->end = 0;
+	args->threads = 0;
+	args->chunks = 0;
+	args->maxmem = 0;
+	args->outfile = NULL;
+	args->infile = NULL;
+	args->error = pfdg_success;
+	args->message = NULL;
+
+	if (argc < 1)
+	{
+		args->error = pfdg_error_command;
+		return args;
+	}
+
+	// Parse command in argv[0]
+	if (STRICMP(argv[0], PFDG_STR_CMD(pfdg_command_help)))
+	{
+		args->command = pfdg_command_help;
+	}
+	else if (STRICMP(argv[0], PFDG_STR_CMD(pfdg_command_sieve)))
+	{
+		args->command = pfdg_command_sieve;
+	}
+	else if (STRICMP(argv[0], PFDG_STR_CMD(pfdg_command_mem)))
+	{
+		args->command = pfdg_command_mem;
+	}
+	else if (STRICMP(argv[0], PFDG_STR_CMD(pfdg_command_read)))
+	{
+		args->command = pfdg_command_read;
+	}
+	else if (STRICMP(argv[0], PFDG_STR_CMD(pfdg_command_test)))
+	{
+		args->command = pfdg_command_test;
+	}
+	else
+	{
+		// Unrecognized command
+		args->error = pfdg_error_command;
+		args->message = argv[0];
+		return args;
+	}
+
+	// Some commands do not accept arguments
+	if (args->command == pfdg_command_help || args->command == pfdg_command_test)
+	{
+		if (argc > 1)
+		{
+			args->error = pfdg_error_number_of_args;
+		}
+		return args;
+	}
+
+	// Parse arguments
+	for (int i = 1; i < argc; ++i)
+	{
+		char* name_str = argv[i];
+		char* value_str = strchr(argv[i], '=');
+		if (!value_str)
+		{
+			args->error = pfdg_error_arg;
+			args->message = argv[i];
+			return args;
+		}
+		*value_str = '\0';
+		++value_str;
+		if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_start)))
+		{
+			uint64_t value = ATOI64(value_str);
+		}
+	}
+
+	return args;
+}
+
+void pfdg_cli_destroy(pfdg_args_t* args)
+{
+	free(args);
+}

--- a/src/cli.c
+++ b/src/cli.c
@@ -59,6 +59,7 @@ bool pfdg_cli_parse_number(char* value_str, uint64_t* res)
 			break;
 		case 'e':
 		case 'E':
+		{
 			char* end2;
 			unsigned long long exponent = strtoull(end + 1, &end2, 10);
 			if (end2 != end + 1 && exponent < POWERS_LEN)
@@ -66,6 +67,7 @@ bool pfdg_cli_parse_number(char* value_str, uint64_t* res)
 				scale = powers[exponent];
 				end = end2;
 			}
+		}
 			break;
 		}
 
@@ -74,13 +76,9 @@ bool pfdg_cli_parse_number(char* value_str, uint64_t* res)
 			return false;
 		}
 
-		if (__builtin_umulll_overflow(value, scale, res))
+		if (__builtin_umulll_overflow(value, scale, &value))
 		{
 			return false;
-		}
-		else
-		{
-			return true;
 		}
 	}
 	*res = value;
@@ -102,30 +100,30 @@ pfdg_args_t* pfdg_cli_parse(const int argc, char** argv)
 	args->error = pfdg_success;
 	args->message = NULL;
 
-	if (argc < 1)
+	if (argc < 2)
 	{
 		args->error = pfdg_error_command;
 		return args;
 	}
 
-	// Parse command in argv[0]
-	if (STRICMP(argv[0], PFDG_STR_CMD(pfdg_command_help)))
+	// Parse command in argv[1]
+	if (STRICMP(argv[1], PFDG_STR_CMD(pfdg_command_help)) == 0)
 	{
 		args->command = pfdg_command_help;
 	}
-	else if (STRICMP(argv[0], PFDG_STR_CMD(pfdg_command_sieve)))
+	else if (STRICMP(argv[1], PFDG_STR_CMD(pfdg_command_sieve)) == 0)
 	{
 		args->command = pfdg_command_sieve;
 	}
-	else if (STRICMP(argv[0], PFDG_STR_CMD(pfdg_command_mem)))
+	else if (STRICMP(argv[1], PFDG_STR_CMD(pfdg_command_mem)) == 0)
 	{
 		args->command = pfdg_command_mem;
 	}
-	else if (STRICMP(argv[0], PFDG_STR_CMD(pfdg_command_read)))
+	else if (STRICMP(argv[1], PFDG_STR_CMD(pfdg_command_read)) == 0)
 	{
 		args->command = pfdg_command_read;
 	}
-	else if (STRICMP(argv[0], PFDG_STR_CMD(pfdg_command_test)))
+	else if (STRICMP(argv[1], PFDG_STR_CMD(pfdg_command_test)) == 0)
 	{
 		args->command = pfdg_command_test;
 	}
@@ -133,27 +131,29 @@ pfdg_args_t* pfdg_cli_parse(const int argc, char** argv)
 	{
 		// Unrecognized command
 		args->error = pfdg_error_command;
-		args->message = argv[0];
+		args->message = argv[1];
 		return args;
 	}
 
 	// Some commands do not accept arguments
 	if (args->command == pfdg_command_help || args->command == pfdg_command_test)
 	{
-		if (argc > 1)
+		if (argc > 2)
 		{
+			// Invalid number of arguments
 			args->error = pfdg_error_number_of_args;
 		}
 		return args;
 	}
 
 	// Parse arguments
-	for (int i = 1; i < argc; ++i)
+	for (int i = 2; i < argc; ++i)
 	{
 		char* name_str = argv[i];
 		char* value_str = strchr(argv[i], '=');
 		if (!value_str)
 		{
+			// Invalid argument
 			args->error = pfdg_error_arg;
 			args->message = argv[i];
 			return args;
@@ -162,15 +162,15 @@ pfdg_args_t* pfdg_cli_parse(const int argc, char** argv)
 		++value_str;
 
 		bool parse_success = false;
-		if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_start)))
+		if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_start)) == 0)
 		{
 			parse_success = pfdg_cli_parse_number(value_str, &args->start);
 		}
-		else if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_end)))
+		else if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_end)) == 0)
 		{
 			parse_success = pfdg_cli_parse_number(value_str, &args->end);
 		}
-		else if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_threads)))
+		else if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_threads)) == 0)
 		{
 			char* end;
 			unsigned long value = strtoul(value_str, &end, 0);
@@ -181,22 +181,57 @@ pfdg_args_t* pfdg_cli_parse(const int argc, char** argv)
 			args->threads = (int)value;
 			parse_success = true;
 		}
-		else if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_chunks)))
+		else if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_chunks)) == 0)
 		{
 			parse_success = pfdg_cli_parse_number(value_str, &args->chunks);
 		}
-		else if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_maxmem)))
+		else if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_maxmem)) == 0)
 		{
 			parse_success = pfdg_cli_parse_number(value_str, &args->maxmem);
+		}
+		else if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_outfile)) == 0)
+		{
+			args->outfile = value_str;
+			parse_success = true;
+		}
+		else if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_infile)) == 0)
+		{
+			args->infile = value_str;
+			parse_success = true;
+		}
+		else
+		{
+			// Invalid argument name
+			args->error = pfdg_error_arg;
+			args->message = name_str;
+			return args;
 		}
 
 		// Stop if parse failed
 		if (!parse_success)
 		{
+			// Invalid argument value
 			args->error = pfdg_error_arg_value;
-			args->message = argv[i];
+			args->message = value_str;
 			return args;
 		}
+	}
+
+	// Validate arguments
+	// End must be greater than start
+	if (args->end <= args->start)
+	{
+		args->error = pfdg_error_arg_value;
+		args->message = PFDG_STR_ARG(pfdg_arg_end);
+		return args;
+	}
+
+	// TODO: Apply defaults for maxmem and threads
+	if (args->chunks == 0)
+	{
+		uint64_t l = (uint64_t)log10floor(args->end);
+		if (l > 0) l--;
+		args->chunks = (uint64_t)args->threads << l;
 	}
 
 	return args;

--- a/src/cli.c
+++ b/src/cli.c
@@ -103,6 +103,7 @@ pfdg_args_t *pfdg_cli_parse(const int argc, char **argv)
 	args->buffer_count = 0;
 	args->chunks = 0;
 	args->maxmem = 0;
+	args->file_size = 0;
 	args->outfile = NULL;
 	args->infile = NULL;
 	args->error = pfdg_success;
@@ -341,6 +342,9 @@ pfdg_args_t *pfdg_cli_parse(const int argc, char **argv)
 	args->maxmem = base_mem + chunk_size * args->buffer_count;
 	// Set actual buffer count excluding threads
 	args->buffer_count = args->buffer_count - args->threads;
+	// Calculate file size
+	if (args->outfile)
+		args->file_size = pfdg_get_file_size(args->start, args->end);
 
 	return args;
 }

--- a/src/cli.c
+++ b/src/cli.c
@@ -292,7 +292,11 @@ pfdg_args_t* pfdg_cli_parse(const int argc, char** argv)
 				return args;
 			}
             // Calculate chunk count
-			args->chunks = pfdg_mem_get_chunk_count_by_size(args->start, args->end, chunk_size);
+			uint64_t new_chunks = pfdg_mem_get_chunk_count_by_size(args->start, args->end, chunk_size);
+			// New chunk count may not be larger. This is due to differences in the rounding of chunk size.
+			// Only apply if the recommended number of chunks grew
+			if (new_chunks > args->chunks)
+				args->chunks = new_chunks;
 		}
 		// If requested memory usage is higher than minimum, and if writing to file, allow allocating more buffer space
 		else if (args->maxmem > min_chunk_mem && args->outfile)

--- a/src/cli.c
+++ b/src/cli.c
@@ -85,7 +85,63 @@ pfdg_args_t* pfdg_cli_parse(const int argc, char** argv)
 		++value_str;
 		if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_start)))
 		{
-			uint64_t value = ATOI64(value_str);
+			char* end;
+			unsigned long long value = strtoull(value_str, &end, 0);
+			if (end == value_str || value >= UINT64_MAX)
+			{
+				args->error = pfdg_error_arg_value;
+				args->message = argv[i];
+				return args;
+			}
+			args->start = (uint64_t)value;
+		}
+		else if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_end)))
+		{
+			char* end;
+			unsigned long long value = strtoull(value_str, &end, 0);
+			if (end == value_str || value >= UINT64_MAX)
+			{
+				args->error = pfdg_error_arg_value;
+				args->message = argv[i];
+				return args;
+			}
+			args->end = (uint64_t)value;
+		}
+		else if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_threads)))
+		{
+			char* end;
+			unsigned long value = strtoul(value_str, &end, 0);
+			if (end == value_str || value >= INT_MAX)
+			{
+				args->error = pfdg_error_arg_value;
+				args->message = argv[i];
+				return args;
+			}
+			args->threads = (int)value;
+		}
+		else if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_chunks)))
+		{
+			char* end;
+			unsigned long long value = strtoull(value_str, &end, 0);
+			if (end == value_str || value >= UINT64_MAX || value < 1)
+			{
+				args->error = pfdg_error_arg_value;
+				args->message = argv[i];
+				return args;
+			}
+			args->chunks = (uint64_t)value;
+		}
+		else if (STRICMP(name_str, PFDG_STR_ARG(pfdg_arg_maxmem)))
+		{
+			char* end;
+			unsigned long long value = strtoull(value_str, &end, 0);
+			if (end == value_str || value == UINT64_MAX || value < 1)
+			{
+				args->error = pfdg_error_arg_value;
+				args->message = argv[i];
+				return args;
+			}
+			args->maxmem = (uint64_t)value;
 		}
 	}
 

--- a/src/cli.h
+++ b/src/cli.h
@@ -55,6 +55,7 @@ typedef struct {
 	uint64_t start;
 	uint64_t end;
 	int threads;
+	int buffer_count;
 	uint64_t chunks;
 	uint64_t maxmem;
 	char* outfile;

--- a/src/cli.h
+++ b/src/cli.h
@@ -1,0 +1,68 @@
+#pragma once
+#include <stdint.h>
+#include "stdafx.h"
+
+typedef enum {
+	pfdg_command_none = 0,
+	pfdg_command_sieve = 1,
+	pfdg_command_mem = 2,
+	pfdg_command_read = 3,
+	pfdg_command_help = 4,
+	pfdg_command_test = 5
+} pfdg_command_t;
+
+static const char* const pfdg_str_cmd[] =
+{
+	"",
+	"sieve",
+	"mem",
+	"read",
+	"help",
+	"test",
+	0
+};
+
+#define PFDG_STR_CMD(x) pfdg_str_cmd[x]
+
+typedef enum {
+	pfdg_arg_none = 0,
+    pfdg_arg_start = 1,
+    pfdg_arg_end = 2,
+    pfdg_arg_threads = 3,
+    pfdg_arg_chunks = 4,
+    pfdg_arg_maxmem = 5,
+    pfdg_arg_outfile = 6,
+    pfdg_arg_infile = 7
+} pfdg_arg_t;
+
+static const char* const pfdg_str_arg[] =
+{
+	"",
+	"start",
+	"end",
+	"threads",
+	"chunks",
+	"maxmem",
+	"outfile",
+	"infile",
+	0
+};
+
+#define PFDG_STR_ARG(x) pfdg_str_arg[x]
+
+typedef struct {
+	pfdg_command_t command;
+	uint64_t start;
+	uint64_t end;
+	int threads;
+	uint64_t chunks;
+	uint64_t maxmem;
+	char* outfile;
+	char* infile;
+	pfdg_error_t error;
+	char* message;
+} pfdg_args_t;
+
+pfdg_args_t* pfdg_cli_parse(const int argc, char** argv);
+
+void pfdg_cli_destroy(pfdg_args_t* args);

--- a/src/cli.h
+++ b/src/cli.h
@@ -60,7 +60,7 @@ typedef struct {
 	char* outfile;
 	char* infile;
 	pfdg_error_t error;
-	char* message;
+	const char* message;
 } pfdg_args_t;
 
 pfdg_args_t* pfdg_cli_parse(const int argc, char** argv);

--- a/src/cli.h
+++ b/src/cli.h
@@ -67,3 +67,5 @@ typedef struct {
 pfdg_args_t* pfdg_cli_parse(const int argc, char** argv);
 
 void pfdg_cli_destroy(pfdg_args_t* args);
+
+void pfdg_cli_print_bytes(uint64_t bytes);

--- a/src/cli.h
+++ b/src/cli.h
@@ -58,6 +58,7 @@ typedef struct {
 	int buffer_count;
 	uint64_t chunks;
 	uint64_t maxmem;
+	uint64_t file_size;
 	char* outfile;
 	char* infile;
 	pfdg_error_t error;

--- a/src/cpuid.h
+++ b/src/cpuid.h
@@ -15,7 +15,7 @@ SINLINE uint64_t __builtin_clzll(uint64_t x)
 	}
 	else
 	{
-		uint64_t leading_zero = 0;
+		unsigned long leading_zero = 0;
 		_BitScanReverse64(&leading_zero, x);
 		return leading_zero ^ 63;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -242,6 +242,12 @@ int main(const int argc, char** argv)
 	printf("Maximum memory usage: ");
 	pfdg_cli_print_bytes(args->maxmem);
 	printf("\n");
+	if (args->file_size > 0)
+	{
+		printf("Expected file size: ");
+		pfdg_cli_print_bytes(args->file_size);
+		printf("\n");
+	}
 	if (args->command == pfdg_command_mem)
 	{
 		return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -216,7 +216,8 @@ int main(const int argc, char** argv)
 		printf("%s: The number of tasks that the computation will be split into. Supports exponent specifiers. This is an advanced option that can be used to tune performance. If unspecified, the value will be calculated as such: %s * 2^MAX(floor(log10(%s)) - 1, 0)\n", PFDG_STR_ARG(pfdg_arg_chunks), PFDG_STR_ARG(pfdg_arg_threads), PFDG_STR_ARG(pfdg_arg_end));
 		printf("%s: Limits the maximum amount of memory to use for computation. Supports exponent specifiers.\n", PFDG_STR_ARG(pfdg_arg_maxmem));
 		printf("%s: The path to a file to which the computation results will be stored. If unspecified, the results will be discarded immediately.\n", PFDG_STR_ARG(pfdg_arg_outfile));
-		printf("\nUsage example: primefdg sieve start=1 end=1e12 threads=8\n");
+		printf("\nUsage example: primefdg sieve end=1e12 threads=8\n");
+		printf("\nExponent specifiers (base 10): k,m,g,t,e\nExponent specifiers (base 2): K,M,G,T\n");
 		return 0;
 	}
 	if (args->command == pfdg_command_test)

--- a/src/main.c
+++ b/src/main.c
@@ -226,7 +226,7 @@ int main(const int argc, char** argv)
 		printf("%s: The end of the range in which to find prime numbers. Supports exponent specifiers. Required.\n", PFDG_STR_ARG(pfdg_arg_end));
 		printf("%s: The number of threads to use for computation. If unspecified or equal to 0, will be set to the number of CPU threads available.\n", PFDG_STR_ARG(pfdg_arg_threads));
 		printf("%s: The number of tasks that the computation will be split into. Supports exponent specifiers. This is an advanced option that can be used to tune performance. If unspecified, the value will be calculated as such: %s * 2^MAX(floor(log10(%s)) - 1, 0)\n", PFDG_STR_ARG(pfdg_arg_chunks), PFDG_STR_ARG(pfdg_arg_threads), PFDG_STR_ARG(pfdg_arg_end));
-		printf("%s: Limits the maximum amount of memory to use for computation. Supports exponent specifiers.\n", PFDG_STR_ARG(pfdg_arg_maxmem));
+		printf("%s: Limits the maximum amount of memory to use for computation. Supports exponent specifiers. If the value of this argument is larger than the amount of memory required by default, and an output file is specified, the extra memory will be used for buffering.\n", PFDG_STR_ARG(pfdg_arg_maxmem));
 		printf("%s: The path to a file to which the computation results will be stored. If unspecified, the results will be discarded immediately.\n", PFDG_STR_ARG(pfdg_arg_outfile));
 		printf("\nUsage example: primefdg sieve end=1e12 threads=8\n");
 		printf("\nExponent specifiers (base 10): k,m,g,t,e\nExponent specifiers (base 2): K,M,G,T\n");
@@ -238,15 +238,20 @@ int main(const int argc, char** argv)
 		return 0;
 	}
 
-	pfdg_timestamp_init();
-
 	printf("Using %i threads, %llu chunks\n", args->threads, args->chunks);
+	printf("Maximum memory usage: %llu KiB\n", args->maxmem >> 10);
+	if (args->command == pfdg_command_mem)
+	{
+		return 0;
+	}
+
+	pfdg_timestamp_init();
 
 	PFDG_TIMESTAMP t_start, t_end;
 	pfdg_timestamp_get(&t_start);
 
 	uint64_t res;
-	const bool r = pfdg_sieve_parallel(args->start, args->end, args->chunks, args->outfile, &res);
+	const bool r = pfdg_sieve_parallel(args->start, args->end, args->chunks, args->buffer_count, args->outfile, &res);
 	if (!r)
 	{
 		printf("Out of memory!");

--- a/src/main.c
+++ b/src/main.c
@@ -226,7 +226,7 @@ int main(const int argc, char** argv)
 		printf("%s: The end of the range in which to find prime numbers. Supports exponent specifiers. Required.\n", PFDG_STR_ARG(pfdg_arg_end));
 		printf("%s: The number of threads to use for computation. If unspecified or equal to 0, will be set to the number of CPU threads available.\n", PFDG_STR_ARG(pfdg_arg_threads));
 		printf("%s: The number of tasks that the computation will be split into. Supports exponent specifiers. This is an advanced option that can be used to tune performance. If unspecified, the value will be calculated as such: %s * 2^MAX(floor(log10(%s)) - 1, 0)\n", PFDG_STR_ARG(pfdg_arg_chunks), PFDG_STR_ARG(pfdg_arg_threads), PFDG_STR_ARG(pfdg_arg_end));
-		printf("%s: Limits the maximum amount of memory to use for computation. Supports exponent specifiers. If the value of this argument is larger than the amount of memory required by default, and an output file is specified, the extra memory will be used for buffering.\n", PFDG_STR_ARG(pfdg_arg_maxmem));
+		printf("%s: Limits the maximum amount of memory to use for computation. Supports exponent specifiers. If the value of this argument is larger than the amount of memory required by default, and an output file is specified, the extra memory will be used for buffering. Note that the actual memory usage will usually be slightly higher.\n", PFDG_STR_ARG(pfdg_arg_maxmem));
 		printf("%s: The path to a file to which the computation results will be stored. If unspecified, the results will be discarded immediately.\n", PFDG_STR_ARG(pfdg_arg_outfile));
 		printf("\nUsage example: primefdg sieve end=1e12 threads=8\n");
 		printf("\nExponent specifiers (base 10): k,m,g,t,e\nExponent specifiers (base 2): K,M,G,T\n");
@@ -239,7 +239,9 @@ int main(const int argc, char** argv)
 	}
 
 	printf("Using %i threads, %llu chunks\n", args->threads, args->chunks);
-	printf("Maximum memory usage: %llu KiB\n", args->maxmem >> 10);
+	printf("Maximum memory usage: ");
+	pfdg_cli_print_bytes(args->maxmem);
+	printf("\n");
 	if (args->command == pfdg_command_mem)
 	{
 		return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -193,6 +193,21 @@ int main(const int argc, char** argv)
 			else
 				printf("Error: Argument \"%s\" value does not meet precondition", args->message);
 			break;
+		case pfdg_error_mem_base:
+			if (args->message == NULL)
+				printf("Error: Not enough memory for essential data - Try increasing the value of \"maxmem\"");
+			else
+				printf("Error: Not enough memory for essential data (%s more bytes required) - Try increasing the value of \"maxmem\"", args->message);
+			break;
+		case pfdg_error_mem_min:
+			if (args->message == NULL)
+				printf("Error: Not enough memory for per-thread computation data - Try increasing the value of \"maxmem\" or \"chunks\", or decreasing the value of \"threads\"");
+			else
+				printf("Error: Not enough memory for per-thread computation data (%s more bytes required) - Try increasing the value of \"maxmem\" or \"chunks\", or decreasing the value of \"threads\"", args->message);
+			break;
+		case pfdg_error_mem_chunk_size:
+			printf("Error: Not enough memory for per-thread computation data - Try increasing the value of \"maxmem\" or decreasing the value of \"threads\"");
+			break;
 		}
 		printf("\nRun \"primefdg help\" for usage information.\n");
 		return 1;

--- a/src/main.c
+++ b/src/main.c
@@ -1,7 +1,4 @@
-﻿// PrimeFDG.cpp : Defines the entry point for the console application.
-//
-
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "pfdg.h"
 #include "timer.h"
 #include "utils.h"
@@ -226,11 +223,9 @@ int main(const int argc, char** argv)
 		return 0;
 	}
 
-	printf("Using %i threads, %llu chunks\n", args->threads, args->chunks);
-
 	pfdg_timestamp_init();
-	if (args->threads > 0)
-		omp_set_num_threads(args->threads);
+
+	printf("Using %i threads, %llu chunks\n", args->threads, args->chunks);
 
 	PFDG_TIMESTAMP t_start, t_end;
 	pfdg_timestamp_get(&t_start);

--- a/src/pfdg.c
+++ b/src/pfdg.c
@@ -24,10 +24,10 @@ uint64_t pfdg_mem_get_chunk_size(const uint64_t start, const uint64_t end, const
 
 uint64_t pfdg_mem_get_chunk_count_by_size(const uint64_t start, const uint64_t end, const uint64_t chunk_size)
 {
-	// Account for 32-byte alignment (TODO: Refactor)
+	// Account for 32-byte alignment
 	uint64_t actual_size = (chunk_size / 32) * 32;
 	uint64_t len = end - start;
-	len = DIVUP(len, BITS(BITARRAY_WORD) * 2);
+	len = DIVUP(len, sizeof(BITARRAY_WORD) * 2);
 	return DIVUP(len, actual_size);
 }
 

--- a/src/pfdg.c
+++ b/src/pfdg.c
@@ -31,6 +31,12 @@ uint64_t pfdg_mem_get_chunk_count_by_size(const uint64_t start, const uint64_t e
 	return DIVUP(len, actual_size);
 }
 
+uint64_t pfdg_get_file_size(const uint64_t start, const uint64_t end)
+{
+	const uint64_t len = end - start;
+	return sizeof(pfdg_file_header) + DIVUP(len, BITS(BITARRAY_WORD) * 2) * sizeof(BITARRAY_WORD);
+}
+
 bitarray* pfdg_init_bitarray(const uint64_t capacity, const uint64_t offset, const bool use_pattern)
 {
 	bitarray* arr = bitarray_create(capacity, true);

--- a/src/pfdg.c
+++ b/src/pfdg.c
@@ -27,7 +27,7 @@ uint64_t pfdg_mem_get_chunk_count_by_size(const uint64_t start, const uint64_t e
 	// Account for 32-byte alignment
 	uint64_t actual_size = (chunk_size / 32) * 32;
 	uint64_t len = end - start;
-	len = DIVUP(len, sizeof(BITARRAY_WORD) * 2);
+	len = DIVUP(len, BITS(BITARRAY_WORD) * 2) * 8;
 	return DIVUP(len, actual_size);
 }
 
@@ -114,7 +114,7 @@ void pfdg_sieve(bitarray* const arr, bitarray* const known, const uint64_t offse
 			pfdg_mark(arr, i, offset);
 }
 
-bool pfdg_sieve_parallel(const uint64_t start, const uint64_t end, uint64_t chunks, const char * const file, uint64_t * const prime_count)
+bool pfdg_sieve_parallel(const uint64_t start, const uint64_t end, uint64_t chunks, const uint64_t buffers, const char * const file, uint64_t * const prime_count)
 {
 	// Step 1
 	bitarray* const known = pfdg_init_bitarray((uint64_t)sqrt((double)end) + 1, 0, true);
@@ -145,7 +145,7 @@ bool pfdg_sieve_parallel(const uint64_t start, const uint64_t end, uint64_t chun
 			fwrite(&h, sizeof(pfdg_file_header), 1, f);
 		}
 
-		io_init(f, chunks);
+		io_init(f, buffers);
 	}
 
 	//PFDG_TIMESTAMP t_start, t_end;

--- a/src/pfdg.h
+++ b/src/pfdg.h
@@ -29,6 +29,13 @@ typedef struct
 
 #define PFDG_HEADER_INITIALIZER { "PFDG", 2, 0, NATIVE_ORDER, sizeof(BITARRAY_WORD), sizeof(pfdg_file_header) }
 
+// Static pattern + prefix + known primes
+uint64_t pfdg_mem_get_base(const uint64_t start, const uint64_t end);
+// Maximum size for single chunk
+uint64_t pfdg_mem_get_chunk_size(const uint64_t start, const uint64_t end, const uint64_t chunks);
+// Get number of chunks by chunk size
+uint64_t pfdg_mem_get_chunk_count_by_size(const uint64_t start, const uint64_t end, const uint64_t chunk_size);
+
 bitarray* pfdg_init_bitarray(const uint64_t capacity, const uint64_t offset, const bool use_pattern);
 void pfdg_mark(bitarray* const arr, const uint64_t prime, const uint64_t offset);
 void pfdg_sieve_seed(bitarray* const arr, const bool skip);

--- a/src/pfdg.h
+++ b/src/pfdg.h
@@ -40,5 +40,5 @@ bitarray* pfdg_init_bitarray(const uint64_t capacity, const uint64_t offset, con
 void pfdg_mark(bitarray* const arr, const uint64_t prime, const uint64_t offset);
 void pfdg_sieve_seed(bitarray* const arr, const bool skip);
 void pfdg_sieve(bitarray* const arr, bitarray* const known, const uint64_t offset, const bool skip);
-bool pfdg_sieve_parallel(const uint64_t start, const uint64_t end, uint64_t chunks, const char * const file, uint64_t * const prime_count);
+bool pfdg_sieve_parallel(const uint64_t start, const uint64_t end, uint64_t chunks, const uint64_t buffers, const char * const file, uint64_t * const prime_count);
 bool pfdg_generate_pattern(const uint64_t last_prime, const char * const file);

--- a/src/pfdg.h
+++ b/src/pfdg.h
@@ -35,6 +35,8 @@ uint64_t pfdg_mem_get_base(const uint64_t start, const uint64_t end);
 uint64_t pfdg_mem_get_chunk_size(const uint64_t start, const uint64_t end, const uint64_t chunks);
 // Get number of chunks by chunk size
 uint64_t pfdg_mem_get_chunk_count_by_size(const uint64_t start, const uint64_t end, const uint64_t chunk_size);
+// File size
+uint64_t pfdg_get_file_size(const uint64_t start, const uint64_t end);
 
 bitarray* pfdg_init_bitarray(const uint64_t capacity, const uint64_t offset, const bool use_pattern);
 void pfdg_mark(bitarray* const arr, const uint64_t prime, const uint64_t offset);

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -27,8 +27,9 @@ typedef enum {
 	pfdg_error_malloc = 1,
 	pfdg_error_command = 2,
 	pfdg_error_arg = 3,
-	pfdg_error_number_of_args = 4,
-	pfdg_error_io = 5
+	pfdg_error_arg_value = 4,
+	pfdg_error_number_of_args = 5,
+	pfdg_error_io = 6
 } pfdg_error_t;
 
 #if _M_X64 || __LP64__

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -30,7 +30,10 @@ typedef enum {
 	pfdg_error_arg = 4,
 	pfdg_error_arg_value = 5,
 	pfdg_error_arg_precondition = 6,
-	pfdg_error_io = 7
+	pfdg_error_mem_base = 7,
+	pfdg_error_mem_min = 8,
+	pfdg_error_mem_chunk_size = 9,
+	pfdg_error_io = 10
 } pfdg_error_t;
 
 #if _M_X64 || __LP64__

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -26,10 +26,11 @@ typedef enum {
 	pfdg_success = 0,
 	pfdg_error_malloc = 1,
 	pfdg_error_command = 2,
-	pfdg_error_arg = 3,
-	pfdg_error_arg_value = 4,
-	pfdg_error_number_of_args = 5,
-	pfdg_error_io = 6
+	pfdg_error_number_of_args = 3,
+	pfdg_error_arg = 4,
+	pfdg_error_arg_value = 5,
+	pfdg_error_arg_precondition = 6,
+	pfdg_error_io = 7
 } pfdg_error_t;
 
 #if _M_X64 || __LP64__

--- a/src/utils.h
+++ b/src/utils.h
@@ -73,7 +73,8 @@ SINLINE void memcpy_aligned8(void*       const destination,
 	}
 }
 
-static const unsigned char guesses[64] = {
+#define GUESSES_LEN 64
+static const unsigned char guesses[GUESSES_LEN] = {
 	0, 0, 0, 0, 1, 1, 1, 2, 2, 2,
 	3, 3, 3, 3, 4, 4, 4, 5, 5, 5,
 	6, 6, 6, 6, 7, 7, 7, 8, 8, 8,
@@ -83,7 +84,8 @@ static const unsigned char guesses[64] = {
 	18, 18, 18, 18
 };
 
-static const uint64_t powers[20] = {
+#define POWERS_LEN 20
+static const uint64_t powers[POWERS_LEN] = {
 	1ull,
 	10ull,
 	100ull,
@@ -106,11 +108,21 @@ static const uint64_t powers[20] = {
 	10000000000000000000ull
 };
 
-SINLINE uint64_t log2floor(uint64_t x) {
+SINLINE uint64_t log2floor(uint64_t x)
+{
 	return x ? 63ull - __builtin_clzll(x) : 0;
 }
 
-SINLINE unsigned log10floor(uint64_t x) {
+SINLINE unsigned log10floor(uint64_t x)
+{
 	unsigned guess = guesses[log2floor(x)];
 	return guess + (x >= powers[guess + 1]);
 }
+
+#ifdef _MSC_VER
+SINLINE bool __builtin_umulll_overflow(unsigned long long a, unsigned long long b, unsigned long long* res)
+{
+	*res = a * b;
+	return b != 0 && *res / b != a;
+}
+#endif


### PR DESCRIPTION
This PR implements a new way to use the CLI which is less confusing and more extensible, plus more validation of the values.
It uses a `dd`-like argument syntax.

Other changes:
- `PrimeFDG.c` was renamed to `main.c`
- Fixed more build issues and warnings related to recent changes

Example:
```
PrimeFDG sieve end=1e12 threads=8
```

TODOs:
- [x] Implement `threads=0`
- [x] Implement `maxmem`
- [x] Implement `mem` command